### PR TITLE
Add config for VSCode Remote

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,14 @@
     "onCommand:fuzzySearch.activeTextEditor",
     "onCommand:fuzzySearch.activeTextEditorWithCurrentSelection"
   ],
+  "homepage": "https://github.com/jacobdufault/vscode-fuzzy-search",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jacobdufault/vscode-fuzzy-search.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jacobdufault/vscode-fuzzy-search/issues"
+  },
   "main": "./out/src/extension",
   "contributes": {
     "commands": [

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     "onCommand:fuzzySearch.activeTextEditor",
     "onCommand:fuzzySearch.activeTextEditorWithCurrentSelection"
   ],
+  "extensionKind": [
+    "ui",
+    "workspace"
+  ],
   "homepage": "https://github.com/jacobdufault/vscode-fuzzy-search",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is a pull request to add configuration that allows this extension to run locally when using VSCode Remote. Concretely, `extensionKind` will make vscode to prefer this extension to run locally instead of on remote; however, it also allows this extension to run on the remote.

While I was at it, I also added links to this repo when this extension is published on visual studio code's extension website.

Let me know if you have any questions :)